### PR TITLE
Fix openfile filter

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,8 +41,7 @@ class Ui(QtWidgets.QMainWindow):
     def Open_File(self):
         print("open file")
         dialog = QtWidgets.QFileDialog()
-        # path, _ = dialog.getOpenFileName(self, "Open File", "", "sound Files (*.mp3 *.ogg *.wav*.m4a);All files (*,*)")
-        path, _ = dialog.getOpenFileName(self, 'Open File', os.getenv('MUSIC_PATH'), 'sound Files (*.mp3 *.ogg *.wav *.m4a *.aac);All files (*,*)')
+        path, _ = dialog.getOpenFileName(self, 'Open File', os.getenv('MUSIC_PATH'), 'Sound Files (*.mp3 *.ogg *.wav *.m4a *.aac)')
         if path != '':
             print("File path: " + path)
             self.add_to_plalist(path)


### PR DESCRIPTION
We only need valid audio files, there's no need to match all files.

However, the reason this didn't work was because of incorrect syntax.

Suppose we wanted to match all files with our filter, this would've had to have happened

```diff
- sound Files (*.mp3 *.ogg *.wav *.m4a *.aac);All files (*,*)
+ sound Files (*.mp3 *.ogg *.wav *.m4a *.aac);; All files (*)
```